### PR TITLE
Fix sorting not using serialized field name

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -46,7 +46,7 @@ GET /users?orderBy[lastName]=desc
 ```
 
 For this query only the status filter and order by id desc will be applied.
-Any keys not in the specified filter or oderBy format will be ignored
+Any keys not in the specified filter or orderBy format will be ignored
 
 ```http
 GET /todos?status[eq]=done&page=1&perPage=10&orderBy[id]=desc

--- a/src/Doctrine/Filter/DoctrineFilter.php
+++ b/src/Doctrine/Filter/DoctrineFilter.php
@@ -90,8 +90,19 @@ class DoctrineFilter
      */
     private function applySorting(array $orderBy): void
     {
+        $exposedFields = $this->exposedFields[$this->getRootEntity()];
+
         foreach ($orderBy as $value) {
-            $this->queryBuilder->addOrderBy(sprintf('%s.%s', $this->getRootAlias(), $value->getField()), $value->getDirection());
+            if (!array_key_exists($value->getField(), $exposedFields)) {
+                continue;
+            }
+
+            $exposedField = $exposedFields[$value->getField()];
+
+            $this->queryBuilder->addOrderBy(
+                sprintf('%s.%s', $this->getRootAlias(), $exposedField->getFieldName()),
+                $value->getDirection()
+            );
         }
     }
 

--- a/tests/DoctrineFilterTest.php
+++ b/tests/DoctrineFilterTest.php
@@ -250,6 +250,7 @@ class DoctrineFilterTest extends BaseTestCase
             ['x.id desc', 'orderBy[id]=asc&orderBy[id]=desc'],
             ['x.id desc', 'orderBy[id]=asc&orderBy[id]=desc'],
             ['', 'this=that&orderBy=asc'],
+            ['x.serializedWithUnderscores asc', 'orderBy[serialized_with_underscores]=asc'],
         ];
     }
 


### PR DESCRIPTION
At present, serialized name attributes on entity fields are used for filtering, but not sorting. Additionally, the current sorting behaviour doesn't validate whether the field name specified either exists on the entity, or is exposed.

I've added a test case which should expose the issue when applied without my fixes, and a change to the `applySorting` method of `DoctrineFilter` to use the `exposedFields` attribute to map the serialized name to the field name when adding sorting to the query builder, and ignores it if not exposed.

The only uncertainty I've got around this is my current solution may break backwards compatibility if anyone was relying on the ordering parameters to use the entity's field name rather than the serialised name. I'd be happy to change this to support the field name as a fallback if the serialised key lookup fails if preferred.